### PR TITLE
パスワード表示ボタンをシングルタップすることで切り替わるように修正 #17

### DIFF
--- a/Insterm/Views/SSHSetupView.swift
+++ b/Insterm/Views/SSHSetupView.swift
@@ -127,9 +127,9 @@ struct SSHSetupView: View {
                     }
                 }
             }
-            .onTapGesture {
+            .simultaneousGesture(TapGesture().onEnded {
                 focusedField = nil
-            }
+            })
             connectButton
         }
     }


### PR DESCRIPTION
## 実施タスク

issue #17 

## 実施内容

- SSHSetupViewのモディファイアを変更（.onTapGesture → .simultaneousGesture(TapGesture().onEnded）

## レビューしてほしいこと

- パスワード表示ボタンをシングルタップして、表示/非表示が切り替わること

## 備考

- iOS 18以降では、親ViewのtapGestureは子ViewsのtapGestures（.onTapGesture、またはButtonの機能）をブロックしてしまう
- 参考URL：[Stack Overflow
](https://stackoverflow.com/questions/79004931/swiftui-list-elements-not-registering-ontapgesture-after-ios-18-upgrade)