### PR TITLE
AppStoreのレビューページへ遷移できない不具合を修正

### DIFF
--- a/Insterm.xcodeproj/project.pbxproj
+++ b/Insterm.xcodeproj/project.pbxproj
@@ -575,7 +575,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2.0.1.1;
+				CURRENT_PROJECT_VERSION = 2.0.2.1;
 				DEVELOPMENT_ASSET_PATHS = "\"Insterm/Preview Content\"";
 				DEVELOPMENT_TEAM = PHRCK7J5L6;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -595,7 +595,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				OTHER_LDFLAGS = (
 					"-fprofile-instr-generate",
 					"-ObjC",
@@ -625,7 +625,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2.0.1.1;
+				CURRENT_PROJECT_VERSION = 2.0.2.1;
 				DEVELOPMENT_ASSET_PATHS = "\"Insterm/Preview Content\"";
 				DEVELOPMENT_TEAM = PHRCK7J5L6;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -644,7 +644,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				OTHER_LDFLAGS = (
 					"-fprofile-instr-generate",
 					"-ObjC",

--- a/Insterm/Views/AppInfoView.swift
+++ b/Insterm/Views/AppInfoView.swift
@@ -11,7 +11,7 @@ import LicenseList
 
 struct AppInfoView: View {
     let items: [AppInfoModel] = [
-        AppInfoModel(title: String(localized: "Write a Review"), iconName: "pencil.circle.fill", destinationView: nil, url: URL(string: "https://apps.apple.com/app/id1662278977?action=write-review")),
+        AppInfoModel(title: String(localized: "Write a Review"), iconName: "pencil.circle.fill", destinationView: nil, url: URL(string: "https://apps.apple.com/app/id6742595334?action=write-review")),
         AppInfoModel(title: String(localized: "Developer"), iconName: "person.fill", destinationView: AnyView(WebViewContainer(url: URL(string:"https://www.yumori.dev")!, title: String(localized: "Developer"))), url: nil),
         AppInfoModel(title: String(localized: "Privacy Policy"), iconName: "lock.shield.fill", destinationView: AnyView(WebViewContainer(url: URL(string: "https://www.yumori.dev/privacy/insterm/")!, title: String(localized: "Privacy Policy"))), url: nil),
         AppInfoModel(title: String(localized: "Library"), iconName: "books.vertical.fill", destinationView: AnyView(LibraryView()), url: nil)


### PR DESCRIPTION
## 実施タスク

- #26 

## 実施内容

- レビューページのURLを修正
- Xcodeのバージョンをv2.0.1→v2.0.2へ変更

## レビューしてほしいこと

- リンクの確認

## 備考

- AppStoreのレビューページはシミュレータでは接続できないため、実機で確認すること
